### PR TITLE
🔧 corriger(sendData.js, userInput.js) : supprimer l'appel de fonction…

### DIFF
--- a/src/sendData.js
+++ b/src/sendData.js
@@ -27,10 +27,5 @@ async function sendConfig() {
   }
 }
 
-sendConfig()
-  .then(() => {})
-  .catch((error) => {
-    throw error;
-  });
-
+// Exportez simplement la fonction sans l'appeler
 module.exports = { sendConfig };

--- a/src/userInput.js
+++ b/src/userInput.js
@@ -46,11 +46,5 @@ function getUserInput() {
   });
 }
 
-// Lancez la fonction getUserInput lors de l'exécution du script
-getUserInput()
-  .then(() => {})
-  .catch((error) => {
-    throw error;
-  });
-
+// Exportez simplement la fonction sans l'appeler
 module.exports = getUserInput;


### PR DESCRIPTION
… inutile

Les appels de fonction inutiles à sendConfig() et getUserInput() ont été supprimés. Ces appels n'étaient pas nécessaires car les fonctions sont exportées pour être utilisées ailleurs.